### PR TITLE
Add better error logging.

### DIFF
--- a/imd.js
+++ b/imd.js
@@ -109,7 +109,7 @@
         return module = {id: moduleId};
       }
       id = _resolveRelativeId(base, id);
-      return _require(id);
+      return _require(id, moduleId);
     });
     var result = factory.apply(null, modules);
     return (module && module.exports) || exports || result;
@@ -144,9 +144,9 @@
     return prefix + terms.join('/');
   }
 
-  function _require(id) {
+  function _require(id, moduleId) {
     if (!(id in _modules)) {
-      throw new ReferenceError('The module "' + id + '" has not been loaded');
+      throw new ReferenceError('The module "' + id + '" has not been loaded' + (moduleId ? ' for ' + moduleId : ''));
     }
     return _modules[id];
   }


### PR DESCRIPTION
This adds better error logging for the missing module case. Otherwise it was difficult to find which module didn't correctly import the dependency.
