### PR TITLE
Fix package version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "imd",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "http://polymer.github.io/LICENSE.txt",
   "ignore": [
     "/.*"


### PR DESCRIPTION
Fix package version in bower.json.

Why:

RE issue #12, IMD is distributed as a Bower package. In order for users
to receive bug fixes, updates, etc new versions of the library must be
released periodically. It's particularly important to release a new
version after critical bug fixes.

Before commit 6021053 the library was fundamentally broken in
Firefox/Safari. There have been no new releases since this commit so
the version distributed on Bower currently doesn't work in those
browsers.

How:
- The first step in releasing a new version of the library on Bower is
  to update the version number in `bower.json`
- Bower packages use the [semver](http://semver.org/) format to specify
  versions. Since this release will carry a bugfix, the 'patch' number
  should be incremented by 1.

TODO:
- This commit contains only the first step for updating the package -
  a new release/tag must also be created. This is left for the maintainer
  of the repo.

Thanks for your time (^_^)
